### PR TITLE
docs: 更新文档和配置中的e-CNY相关文本

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -46,7 +46,7 @@ export default defineConfig({
               },
             },
             {
-              label: "Register ECNY",
+              label: "Register e-CNY",
               slug: "guides/registerecny",
               translations: {
                 "zh-CN": "注册",
@@ -117,7 +117,7 @@ export default defineConfig({
         {
           icon: "github",
           label: "GitHub",
-          href: "https://github.com/anson2dev/ecny-you-know",
+          href: "https://github.com/anson2dev/ecnyuk",
         },
         { icon: "discord", label: "Discord", href: "https://diccord.com/" },
         { icon: "x.com", label: "X.com", href: "https://x.com/" },

--- a/src/content/docs/cn/supporter.mdx
+++ b/src/content/docs/cn/supporter.mdx
@@ -1,6 +1,7 @@
 ---
 title: 感谢您们!
 description: e-CNY everything, you need to know
+tableOfContents: false
 hero:
   tagline: 感谢我们的贡献者和赞助商!
   image:

--- a/src/content/docs/supporter.mdx
+++ b/src/content/docs/supporter.mdx
@@ -1,6 +1,7 @@
 ---
 title: Thanks you!
 description: e-CNY everything, you need to know
+tableOfContents: false
 hero:
   tagline: Thanks our cotributors and sponsors!
   image:


### PR DESCRIPTION
更新了文档中的`tableOfContents`配置，并修正了`astro.config.mjs`中的e-CNY相关文本和GitHub链接，确保一致性和准确性。